### PR TITLE
feat(timer): add Live Activity and Dynamic Island support

### DIFF
--- a/TimeMyLifeApp.xcodeproj/project.pbxproj
+++ b/TimeMyLifeApp.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		85ACE4642EE8CC580095117F /* TimeMyLifeWatch Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 85ACE4442EE8CC570095117F /* TimeMyLifeWatch Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		85AEEEFC2F8784F400A704A2 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85AEEEFB2F8784F400A704A2 /* WidgetKit.framework */; };
+		85AEEEFE2F8784F400A704A2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 85AEEEFD2F8784F400A704A2 /* SwiftUI.framework */; };
+		85AEEF0D2F8784F400A704A2 /* TimeMyLifeWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 85AEEEF92F8784F400A704A2 /* TimeMyLifeWidgetsExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -46,6 +49,13 @@
 			remoteGlobalIDString = 85ACE4432EE8CC570095117F;
 			remoteInfo = "TimeMyLifeWatch Watch App";
 		};
+		85AEEF0B2F8784F400A704A2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 85ACE3722EE8C28C0095117F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 85AEEEF82F8784F400A704A2;
+			remoteInfo = TimeMyLifeWidgetsExtension;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -60,6 +70,17 @@
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		85AEEF122F8784F400A704A2 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				85AEEF0D2F8784F400A704A2 /* TimeMyLifeWidgetsExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -69,6 +90,9 @@
 		85ACE4442EE8CC570095117F /* TimeMyLifeWatch Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TimeMyLifeWatch Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		85ACE4502EE8CC580095117F /* TimeMyLifeWatch Watch AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TimeMyLifeWatch Watch AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		85ACE45A2EE8CC580095117F /* TimeMyLifeWatch Watch AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "TimeMyLifeWatch Watch AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		85AEEEF92F8784F400A704A2 /* TimeMyLifeWidgetsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TimeMyLifeWidgetsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		85AEEEFB2F8784F400A704A2 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		85AEEEFD2F8784F400A704A2 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -105,6 +129,20 @@
 			);
 			target = 85ACE4432EE8CC570095117F /* TimeMyLifeWatch Watch App */;
 		};
+		85AEEF112F8784F400A704A2 /* Exceptions for "TimeMyLifeWidgets" folder in "TimeMyLifeWidgetsExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 85AEEEF82F8784F400A704A2 /* TimeMyLifeWidgetsExtension */;
+		};
+		85AEEF202F8785A000A704A2 /* Exceptions for "TimeMyLifeApp" folder in "TimeMyLifeWidgetsExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Models/TimerActivityAttributes.swift,
+			);
+			target = 85AEEEF82F8784F400A704A2 /* TimeMyLifeWidgetsExtension */;
+		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -113,6 +151,7 @@
 			exceptions = (
 				85ACE39D2EE8C28C0095117F /* Exceptions for "TimeMyLifeApp" folder in "TimeMyLifeApp" target */,
 				85ACE4702EE8DC260095117F /* Exceptions for "TimeMyLifeApp" folder in "TimeMyLifeWatch Watch App" target */,
+				85AEEF202F8785A000A704A2 /* Exceptions for "TimeMyLifeApp" folder in "TimeMyLifeWidgetsExtension" target */,
 			);
 			path = TimeMyLifeApp;
 			sourceTree = "<group>";
@@ -140,6 +179,14 @@
 		85ACE45D2EE8CC580095117F /* TimeMyLifeWatch Watch AppUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "TimeMyLifeWatch Watch AppUITests";
+			sourceTree = "<group>";
+		};
+		85AEEEFF2F8784F400A704A2 /* TimeMyLifeWidgets */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				85AEEF112F8784F400A704A2 /* Exceptions for "TimeMyLifeWidgets" folder in "TimeMyLifeWidgetsExtension" target */,
+			);
+			path = TimeMyLifeWidgets;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -187,6 +234,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		85AEEEF62F8784F400A704A2 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				85AEEEFE2F8784F400A704A2 /* SwiftUI.framework in Frameworks */,
+				85AEEEFC2F8784F400A704A2 /* WidgetKit.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -199,6 +255,8 @@
 				85ACE4452EE8CC570095117F /* TimeMyLifeWatch Watch App */,
 				85ACE4532EE8CC580095117F /* TimeMyLifeWatch Watch AppTests */,
 				85ACE45D2EE8CC580095117F /* TimeMyLifeWatch Watch AppUITests */,
+				85AEEEFF2F8784F400A704A2 /* TimeMyLifeWidgets */,
+				85AEEEFA2F8784F400A704A2 /* Frameworks */,
 				85ACE37B2EE8C28C0095117F /* Products */,
 			);
 			sourceTree = "<group>";
@@ -212,8 +270,18 @@
 				85ACE4442EE8CC570095117F /* TimeMyLifeWatch Watch App.app */,
 				85ACE4502EE8CC580095117F /* TimeMyLifeWatch Watch AppTests.xctest */,
 				85ACE45A2EE8CC580095117F /* TimeMyLifeWatch Watch AppUITests.xctest */,
+				85AEEEF92F8784F400A704A2 /* TimeMyLifeWidgetsExtension.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		85AEEEFA2F8784F400A704A2 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				85AEEEFB2F8784F400A704A2 /* WidgetKit.framework */,
+				85AEEEFD2F8784F400A704A2 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -227,11 +295,13 @@
 				85ACE3772EE8C28C0095117F /* Frameworks */,
 				85ACE3782EE8C28C0095117F /* Resources */,
 				85ACE4682EE8CC580095117F /* Embed Watch Content */,
+				85AEEF122F8784F400A704A2 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				85ACE4632EE8CC580095117F /* PBXTargetDependency */,
+				85AEEF0C2F8784F400A704A2 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				85ACE37C2EE8C28C0095117F /* TimeMyLifeApp */,
@@ -357,6 +427,28 @@
 			productReference = 85ACE45A2EE8CC580095117F /* TimeMyLifeWatch Watch AppUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		85AEEEF82F8784F400A704A2 /* TimeMyLifeWidgetsExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 85AEEF0E2F8784F400A704A2 /* Build configuration list for PBXNativeTarget "TimeMyLifeWidgetsExtension" */;
+			buildPhases = (
+				85AEEEF52F8784F400A704A2 /* Sources */,
+				85AEEEF62F8784F400A704A2 /* Frameworks */,
+				85AEEEF72F8784F400A704A2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				85AEEEFF2F8784F400A704A2 /* TimeMyLifeWidgets */,
+			);
+			name = TimeMyLifeWidgetsExtension;
+			packageProductDependencies = (
+			);
+			productName = TimeMyLifeWidgetsExtension;
+			productReference = 85AEEEF92F8784F400A704A2 /* TimeMyLifeWidgetsExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -389,6 +481,9 @@
 						CreatedOnToolsVersion = 26.0;
 						TestTargetID = 85ACE4432EE8CC570095117F;
 					};
+					85AEEEF82F8784F400A704A2 = {
+						CreatedOnToolsVersion = 26.0;
+					};
 				};
 			};
 			buildConfigurationList = 85ACE3752EE8C28C0095117F /* Build configuration list for PBXProject "TimeMyLifeApp" */;
@@ -411,6 +506,7 @@
 				85ACE4432EE8CC570095117F /* TimeMyLifeWatch Watch App */,
 				85ACE44F2EE8CC580095117F /* TimeMyLifeWatch Watch AppTests */,
 				85ACE4592EE8CC580095117F /* TimeMyLifeWatch Watch AppUITests */,
+				85AEEEF82F8784F400A704A2 /* TimeMyLifeWidgetsExtension */,
 			);
 		};
 /* End PBXProject section */
@@ -452,6 +548,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		85ACE4582EE8CC580095117F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		85AEEEF72F8784F400A704A2 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -503,6 +606,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		85AEEEF52F8784F400A704A2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -530,6 +640,11 @@
 			isa = PBXTargetDependency;
 			target = 85ACE4432EE8CC570095117F /* TimeMyLifeWatch Watch App */;
 			targetProxy = 85ACE4622EE8CC580095117F /* PBXContainerItemProxy */;
+		};
+		85AEEF0C2F8784F400A704A2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 85AEEEF82F8784F400A704A2 /* TimeMyLifeWidgetsExtension */;
+			targetProxy = 85AEEF0B2F8784F400A704A2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -953,6 +1068,66 @@
 			};
 			name = Release;
 		};
+		85AEEF0F2F8784F400A704A2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4SQ6CVUFYA;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TimeMyLifeWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TimeMyLifeWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = chanmin.TimeMyLifeApp.TimeMyLifeWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		85AEEF102F8784F400A704A2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 4SQ6CVUFYA;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TimeMyLifeWidgets/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = TimeMyLifeWidgets;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = chanmin.TimeMyLifeApp.TimeMyLifeWidgets;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1015,6 +1190,15 @@
 			buildConfigurations = (
 				85ACE46D2EE8CC580095117F /* Debug */,
 				85ACE46E2EE8CC580095117F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		85AEEF0E2F8784F400A704A2 /* Build configuration list for PBXNativeTarget "TimeMyLifeWidgetsExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				85AEEF0F2F8784F400A704A2 /* Debug */,
+				85AEEF102F8784F400A704A2 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TimeMyLifeApp.xcodeproj/xcuserdata/chanminpark.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/TimeMyLifeApp.xcodeproj/xcuserdata/chanminpark.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,12 +7,17 @@
 		<key>TimeMyLifeApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 		<key>TimeMyLifeWatch Watch App.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
+		</dict>
+		<key>TimeMyLifeWidgetsExtension.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>2</integer>
 		</dict>
 	</dict>
 </dict>

--- a/TimeMyLifeApp/Models/TimerActivityAttributes.swift
+++ b/TimeMyLifeApp/Models/TimerActivityAttributes.swift
@@ -1,0 +1,29 @@
+//
+//  TimerActivityAttributes.swift
+//  TimeMyLifeApp
+//
+
+import ActivityKit
+import Foundation
+
+/// Defines the data model for the timer Live Activity (Lock Screen + Dynamic Island).
+/// Static properties are set once when the activity starts; ContentState is updated dynamically.
+public struct TimerActivityAttributes: ActivityAttributes {
+    // MARK: - Dynamic Content State
+
+    public struct ContentState: Codable, Hashable {
+        /// The time the timer was started (used with Text(.timerInterval:) for live counting)
+        public var timerStartDate: Date
+    }
+
+    // MARK: - Static Properties (set once at start)
+
+    /// Name of the activity being timed
+    public var activityName: String
+
+    /// Emoji icon for the activity
+    public var activityEmoji: String
+
+    /// Hex color string for the activity (e.g., "#FFB3BA")
+    public var activityColorHex: String
+}

--- a/TimeMyLifeApp/Services/LiveActivityService.swift
+++ b/TimeMyLifeApp/Services/LiveActivityService.swift
@@ -20,11 +20,18 @@ public final class LiveActivityService {
     // MARK: - Public Methods
 
     /// Starts a Live Activity for the given timer session.
+    /// - Parameters:
+    ///   - activityName: Display name of the activity
+    ///   - activityEmoji: Emoji icon for the activity
+    ///   - activityColorHex: Hex color string for the activity
+    ///   - startDate: When the timer started
+    ///   - accumulatedTime: Time already logged for this activity today (seconds)
     func start(
         activityName: String,
         activityEmoji: String,
         activityColorHex: String,
-        startDate: Date
+        startDate: Date,
+        accumulatedTime: TimeInterval = 0
     ) {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else {
             #if DEBUG
@@ -39,8 +46,12 @@ public final class LiveActivityService {
             activityColorHex: activityColorHex
         )
 
+        // Offset the start date by accumulated time so the widget timer
+        // shows total time for the day, not just the current session.
+        let adjustedStartDate = startDate.addingTimeInterval(-accumulatedTime)
+
         let contentState = TimerActivityAttributes.ContentState(
-            timerStartDate: startDate
+            timerStartDate: adjustedStartDate
         )
 
         let content = ActivityContent(state: contentState, staleDate: nil)

--- a/TimeMyLifeApp/Services/LiveActivityService.swift
+++ b/TimeMyLifeApp/Services/LiveActivityService.swift
@@ -1,0 +1,91 @@
+//
+//  LiveActivityService.swift
+//  TimeMyLifeApp
+//
+
+import ActivityKit
+import Foundation
+
+/// Type alias to disambiguate ActivityKit.Activity from the SwiftData Activity model.
+private typealias LiveActivity = ActivityKit.Activity<TimerActivityAttributes>
+
+/// Manages the timer Live Activity lifecycle (start, update, end).
+@MainActor
+public final class LiveActivityService {
+
+    // MARK: - Properties
+
+    private var currentActivity: LiveActivity?
+
+    // MARK: - Public Methods
+
+    /// Starts a Live Activity for the given timer session.
+    func start(
+        activityName: String,
+        activityEmoji: String,
+        activityColorHex: String,
+        startDate: Date
+    ) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            #if DEBUG
+            print("⚠️ LiveActivityService: Live Activities not enabled")
+            #endif
+            return
+        }
+
+        let attributes = TimerActivityAttributes(
+            activityName: activityName,
+            activityEmoji: activityEmoji,
+            activityColorHex: activityColorHex
+        )
+
+        let contentState = TimerActivityAttributes.ContentState(
+            timerStartDate: startDate
+        )
+
+        let content = ActivityContent(state: contentState, staleDate: nil)
+
+        do {
+            currentActivity = try LiveActivity.request(
+                attributes: attributes,
+                content: content,
+                pushType: nil
+            )
+            #if DEBUG
+            print("✅ LiveActivityService: Started Live Activity for '\(activityName)'")
+            #endif
+        } catch {
+            #if DEBUG
+            print("❌ LiveActivityService: Failed to start Live Activity: \(error)")
+            #endif
+        }
+    }
+
+    /// Ends the current Live Activity.
+    func stop() {
+        guard let activity = currentActivity else { return }
+
+        let finalContent = ActivityContent(
+            state: activity.content.state,
+            staleDate: nil
+        )
+
+        Task {
+            await activity.end(finalContent, dismissalPolicy: .immediate)
+            #if DEBUG
+            print("✅ LiveActivityService: Ended Live Activity")
+            #endif
+        }
+
+        currentActivity = nil
+    }
+
+    /// Ends all timer Live Activities (cleanup on app launch).
+    func endAll() {
+        Task {
+            for activity in LiveActivity.activities {
+                await activity.end(nil, dismissalPolicy: .immediate)
+            }
+        }
+    }
+}

--- a/TimeMyLifeApp/Services/TimerService.swift
+++ b/TimeMyLifeApp/Services/TimerService.swift
@@ -342,6 +342,9 @@ public class TimerService {
     // MARK: - Private Methods
 
     /// Fetches the accumulated duration already logged for an activity on a given date.
+    /// The Live Activity widget runs in a separate process and can't observe the app's
+    /// in-memory timer state. We offset its start date by the accumulated time so the
+    /// widget's `Text(.timerInterval:)` produces the same total as the in-app display.
     private func fetchAccumulatedTime(activityID: UUID, date: Date) -> TimeInterval {
         let normalizedDate = Calendar.current.startOfDay(for: date)
         let predicate = #Predicate<TimeEntry> { entry in

--- a/TimeMyLifeApp/Services/TimerService.swift
+++ b/TimeMyLifeApp/Services/TimerService.swift
@@ -65,10 +65,15 @@ public class TimerService {
     private var timer: Timer?
     private var startTime: Date?
     private let modelContext: ModelContext
-    
+
     // Combine subjects for publishing changes
     private let elapsedTimeSubject = CurrentValueSubject<TimeInterval, Never>(0)
     private let isRunningSubject = CurrentValueSubject<Bool, Never>(false)
+
+    #if os(iOS)
+    /// Service for managing the Live Activity (Lock Screen / Dynamic Island)
+    private let liveActivityService = LiveActivityService()
+    #endif
 
     // MARK: - Initialization
 
@@ -109,6 +114,16 @@ public class TimerService {
         // Start UI updates
         startTimerUpdates()
 
+        // Start Live Activity (iOS only)
+        #if os(iOS)
+        liveActivityService.start(
+            activityName: activity.name,
+            activityEmoji: activity.emoji,
+            activityColorHex: activity.colorHex,
+            startDate: startTime!
+        )
+        #endif
+
         #if DEBUG
         print("✅ TimerService: Started timer for '\(activity.name)'")
         #endif
@@ -138,6 +153,11 @@ public class TimerService {
 
         // Stop UI updates
         stopTimerUpdates()
+
+        // End Live Activity (iOS only)
+        #if os(iOS)
+        liveActivityService.stop()
+        #endif
 
         // Reset local state
         self.isRunning = false
@@ -171,6 +191,16 @@ public class TimerService {
 
         // Start UI updates
         startTimerUpdates()
+
+        // Start Live Activity on resume (iOS only)
+        #if os(iOS)
+        liveActivityService.start(
+            activityName: activity.name,
+            activityEmoji: activity.emoji,
+            activityColorHex: activity.colorHex,
+            startDate: startTime
+        )
+        #endif
 
         #if DEBUG
         print("✅ TimerService: Resumed timer for '\(activity.name)', elapsed: \(formatDuration(elapsedTime))")
@@ -257,6 +287,11 @@ public class TimerService {
         activeTimer.startDate = nil
         activeTimer.isRunning = false
         try modelContext.save()
+
+        // End all Live Activities (iOS only)
+        #if os(iOS)
+        liveActivityService.endAll()
+        #endif
 
         #if DEBUG
         print("✅ TimerService: Reset timer state")

--- a/TimeMyLifeApp/Services/TimerService.swift
+++ b/TimeMyLifeApp/Services/TimerService.swift
@@ -276,6 +276,13 @@ public class TimerService {
         return try ActiveTimer.shared(in: modelContext)
     }
 
+    /// Ends all Live Activities (cleanup after force-kill or stale state).
+    public func endAllLiveActivities() {
+        #if os(iOS)
+        liveActivityService.endAll()
+        #endif
+    }
+
     /// Resets the timer state (for testing/clearing data)
     /// - Throws: Error if save fails
     public func reset() throws {

--- a/TimeMyLifeApp/Services/TimerService.swift
+++ b/TimeMyLifeApp/Services/TimerService.swift
@@ -116,11 +116,13 @@ public class TimerService {
 
         // Start Live Activity (iOS only)
         #if os(iOS)
+        let accumulated = fetchAccumulatedTime(activityID: activity.id, date: normalizedDate)
         liveActivityService.start(
             activityName: activity.name,
             activityEmoji: activity.emoji,
             activityColorHex: activity.colorHex,
-            startDate: startTime!
+            startDate: startTime!,
+            accumulatedTime: accumulated
         )
         #endif
 
@@ -194,11 +196,13 @@ public class TimerService {
 
         // Start Live Activity on resume (iOS only)
         #if os(iOS)
+        let accumulated = fetchAccumulatedTime(activityID: activity.id, date: normalizedDate)
         liveActivityService.start(
             activityName: activity.name,
             activityEmoji: activity.emoji,
             activityColorHex: activity.colorHex,
-            startDate: startTime
+            startDate: startTime,
+            accumulatedTime: accumulated
         )
         #endif
 
@@ -336,6 +340,16 @@ public class TimerService {
     }
 
     // MARK: - Private Methods
+
+    /// Fetches the accumulated duration already logged for an activity on a given date.
+    private func fetchAccumulatedTime(activityID: UUID, date: Date) -> TimeInterval {
+        let normalizedDate = Calendar.current.startOfDay(for: date)
+        let predicate = #Predicate<TimeEntry> { entry in
+            entry.activityID == activityID && entry.date == normalizedDate
+        }
+        let descriptor = FetchDescriptor<TimeEntry>(predicate: predicate)
+        return (try? modelContext.fetch(descriptor).first?.totalDuration) ?? 0
+    }
 
     private func startTimerUpdates() {
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in

--- a/TimeMyLifeApp/TimeMyLifeAppApp.swift
+++ b/TimeMyLifeApp/TimeMyLifeAppApp.swift
@@ -164,8 +164,8 @@ struct TimeMyLifeAppApp: App {
         }
     }
 
-    /// Checks if a timer is running when app becomes active.
-    /// Ends any stale Live Activities and starts a fresh one if a timer is still running.
+    /// Checks if a timer was left running from a previous session (e.g. force-kill).
+    /// Saves the elapsed time, stops the timer, and cleans up stale Live Activities.
     private func checkForRunningTimer() {
         Task { @MainActor in
             do {
@@ -179,13 +179,24 @@ struct TimeMyLifeAppApp: App {
                 if activeTimer.isRunning,
                    let activityID = activeTimer.activityID,
                    let startTime = activeTimer.startTime,
-                   let activity = try dataService.fetchActivity(id: activityID) {
-                    // Restore the timer and start a fresh Live Activity
-                    try timerService.restoreTimerState(from: activeTimer, activity: activity)
+                   let startDate = activeTimer.startDate {
+                    // Save the elapsed time from the orphaned timer session
+                    let elapsed = Date().timeIntervalSince(startTime)
+                    try dataService.createOrUpdateTimeEntry(
+                        activityID: activityID,
+                        date: startDate,
+                        duration: elapsed
+                    )
+
+                    // Clear the active timer state
+                    activeTimer.activityID = nil
+                    activeTimer.startTime = nil
+                    activeTimer.startDate = nil
+                    activeTimer.isRunning = false
+                    try context.save()
 
                     #if DEBUG
-                    let elapsed = Date().timeIntervalSince(startTime)
-                    print("✅ Timer restored - elapsed: \(formatElapsed(elapsed))")
+                    print("✅ Orphaned timer saved and stopped - elapsed: \(formatElapsed(elapsed))")
                     #endif
                 }
             } catch {

--- a/TimeMyLifeApp/TimeMyLifeAppApp.swift
+++ b/TimeMyLifeApp/TimeMyLifeAppApp.swift
@@ -164,19 +164,28 @@ struct TimeMyLifeAppApp: App {
         }
     }
 
-    /// Checks if a timer is running when app becomes active
+    /// Checks if a timer is running when app becomes active.
+    /// Ends any stale Live Activities and starts a fresh one if a timer is still running.
     private func checkForRunningTimer() {
         Task { @MainActor in
             do {
                 let context = modelContainer.mainContext
-                let timer = try ActiveTimer.shared(in: context)
+                let activeTimer = try ActiveTimer.shared(in: context)
 
-                if timer.isRunning {
+                // Clean up any Live Activities left over from a previous app session
+                // (e.g. after a force-kill where we had no chance to end them).
+                timerService.endAllLiveActivities()
+
+                if activeTimer.isRunning,
+                   let activityID = activeTimer.activityID,
+                   let startTime = activeTimer.startTime,
+                   let activity = try dataService.fetchActivity(id: activityID) {
+                    // Restore the timer and start a fresh Live Activity
+                    try timerService.restoreTimerState(from: activeTimer, activity: activity)
+
                     #if DEBUG
-                    if let startTime = timer.startTime {
-                        let elapsed = Date().timeIntervalSince(startTime)
-                        print("✅ Timer is running - elapsed: \(formatElapsed(elapsed))")
-                    }
+                    let elapsed = Date().timeIntervalSince(startTime)
+                    print("✅ Timer restored - elapsed: \(formatElapsed(elapsed))")
                     #endif
                 }
             } catch {

--- a/TimeMyLifeWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TimeMyLifeWidgets/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeMyLifeWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TimeMyLifeWidgets/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeMyLifeWidgets/Assets.xcassets/Contents.json
+++ b/TimeMyLifeWidgets/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeMyLifeWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/TimeMyLifeWidgets/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TimeMyLifeWidgets/Info.plist
+++ b/TimeMyLifeWidgets/Info.plist
@@ -2,11 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSSupportsLiveActivities</key>
-	<true/>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>remote-notification</string>
-	</array>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
 </dict>
 </plist>

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsBundle.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsBundle.swift
@@ -1,0 +1,16 @@
+//
+//  TimeMyLifeWidgetsBundle.swift
+//  TimeMyLifeWidgets
+//
+//  Created by Chanmin Park on 4/8/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct TimeMyLifeWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        TimeMyLifeWidgetsLiveActivity()
+    }
+}

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -73,6 +73,8 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
             )
             .font(.system(.title, design: .rounded, weight: .bold))
             .monospacedDigit()
+            .multilineTextAlignment(.trailing)
+            .frame(alignment: .trailing)
             .foregroundStyle(activityColor(hex: context.attributes.activityColorHex))
         }
         .padding(16)

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -1,0 +1,158 @@
+//
+//  TimeMyLifeWidgetsLiveActivity.swift
+//  TimeMyLifeWidgets
+//
+//  Created by Chanmin Park on 4/8/26.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+struct TimeMyLifeWidgetsLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: TimerActivityAttributes.self) { context in
+            // MARK: - Lock Screen / Banner UI
+            lockScreenView(context: context)
+
+        } dynamicIsland: { context in
+            DynamicIsland {
+                // MARK: - Expanded Dynamic Island
+                DynamicIslandExpandedRegion(.leading) {
+                    activityIcon(context: context, size: 36)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(
+                        timerInterval: context.state.timerStartDate...Date.distantFuture,
+                        countsDown: false
+                    )
+                    .font(.system(.title2, design: .rounded, weight: .bold))
+                    .monospacedDigit()
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.attributes.activityName)
+                        .font(.system(.body, design: .rounded, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            } compactLeading: {
+                // MARK: - Compact Leading
+                activityIcon(context: context, size: 24)
+            } compactTrailing: {
+                // MARK: - Compact Trailing
+                Text(
+                    timerInterval: context.state.timerStartDate...Date.distantFuture,
+                    countsDown: false
+                )
+                .font(.system(.caption, design: .rounded, weight: .semibold))
+                .monospacedDigit()
+                .frame(width: 52)
+            } minimal: {
+                // MARK: - Minimal
+                activityIcon(context: context, size: 22)
+            }
+        }
+    }
+
+    // MARK: - Lock Screen View
+
+    @ViewBuilder
+    private func lockScreenView(context: ActivityViewContext<TimerActivityAttributes>) -> some View {
+        HStack(spacing: 14) {
+            activityIcon(context: context, size: 44)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(context.attributes.activityName)
+                    .font(.system(.headline, design: .rounded, weight: .semibold))
+                    .lineLimit(1)
+
+                Text("Timer running")
+                    .font(.system(.caption, design: .rounded))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            Text(
+                timerInterval: context.state.timerStartDate...Date.distantFuture,
+                countsDown: false
+            )
+            .font(.system(.title, design: .rounded, weight: .bold))
+            .monospacedDigit()
+            .foregroundStyle(activityColor(hex: context.attributes.activityColorHex))
+        }
+        .padding(16)
+        .activityBackgroundTint(Color(.systemBackground))
+        .activitySystemActionForegroundColor(activityColor(hex: context.attributes.activityColorHex))
+    }
+
+    // MARK: - Helpers
+
+    @ViewBuilder
+    private func activityIcon(context: ActivityViewContext<TimerActivityAttributes>, size: CGFloat) -> some View {
+        let emoji = context.attributes.activityEmoji
+        let color = activityColor(hex: context.attributes.activityColorHex)
+
+        if emoji.isEmpty {
+            RoundedRectangle(cornerRadius: size * 0.3)
+                .fill(color)
+                .frame(width: size, height: size)
+        } else {
+            Text(emoji)
+                .font(.system(size: size * 0.6))
+                .frame(width: size, height: size)
+                .background(
+                    RoundedRectangle(cornerRadius: size * 0.3)
+                        .fill(color.opacity(0.3))
+                )
+        }
+    }
+
+    private func activityColor(hex: String) -> Color {
+        Color(hex: hex) ?? Color(red: 0.545, green: 0.498, blue: 0.910)
+    }
+}
+
+// MARK: - Color Extension (duplicated for widget target which can't access main app's Color+Hex)
+
+private extension Color {
+    init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+
+        guard hexSanitized.count == 6 else { return nil }
+
+        var rgb: UInt64 = 0
+        guard Scanner(string: hexSanitized).scanHexInt64(&rgb) else { return nil }
+
+        let red = Double((rgb & 0xFF0000) >> 16) / 255.0
+        let green = Double((rgb & 0x00FF00) >> 8) / 255.0
+        let blue = Double(rgb & 0x0000FF) / 255.0
+
+        self.init(red: red, green: green, blue: blue)
+    }
+}
+
+// MARK: - Previews
+
+extension TimerActivityAttributes {
+    fileprivate static var preview: TimerActivityAttributes {
+        TimerActivityAttributes(
+            activityName: "Reading",
+            activityEmoji: "📚",
+            activityColorHex: "#FFB3BA"
+        )
+    }
+}
+
+extension TimerActivityAttributes.ContentState {
+    fileprivate static var running: TimerActivityAttributes.ContentState {
+        TimerActivityAttributes.ContentState(timerStartDate: Date())
+    }
+}
+
+#Preview("Notification", as: .content, using: TimerActivityAttributes.preview) {
+    TimeMyLifeWidgetsLiveActivity()
+} contentStates: {
+    TimerActivityAttributes.ContentState.running
+}

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -46,7 +46,7 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 // MARK: - Compact Leading
                 Text(context.attributes.activityEmoji.isEmpty ? "⏱" : context.attributes.activityEmoji)
                     .font(.system(size: 14))
-                    .padding(.leading, 4)
+                    .padding(.leading, 6)
             } compactTrailing: {
                 // MARK: - Compact Trailing
                 Text(
@@ -55,8 +55,8 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 )
                 .font(.system(size: 12, weight: .semibold, design: .rounded))
                 .monospacedDigit()
-                .frame(width: 42)
-                .padding(.trailing, 4)
+                .frame(width: 30)
+                .padding(.trailing, 0)
             } minimal: {
                 // MARK: - Minimal
                 activityIcon(context: context, size: 22)
@@ -70,11 +70,12 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
     @ViewBuilder
     private func lockScreenView(context: ActivityViewContext<TimerActivityAttributes>) -> some View {
         HStack(spacing: 14) {
-            activityIcon(context: context, size: 44)
+            activityIcon(context: context, size: 50)
 
             Text(context.attributes.activityName)
-                .font(.system(.headline, design: .rounded, weight: .semibold))
+                .font(.system(size: 14, weight: .semibold, design: .rounded))
                 .lineLimit(1)
+                .layoutPriority(1)
 
             Spacer()
 
@@ -85,11 +86,9 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
             .font(.system(.title, design: .rounded, weight: .bold))
             .monospacedDigit()
             .multilineTextAlignment(.trailing)
-            .frame(alignment: .trailing)
             .foregroundStyle(activityColor(hex: context.attributes.activityColorHex))
-            .fixedSize()
         }
-        .padding(16)
+        .padding(20)
         .activityBackgroundTint(Color(.systemBackground))
         .activitySystemActionForegroundColor(activityColor(hex: context.attributes.activityColorHex))
     }
@@ -146,7 +145,7 @@ private extension Color {
 extension TimerActivityAttributes {
     fileprivate static var preview: TimerActivityAttributes {
         TimerActivityAttributes(
-            activityName: "Reading",
+            activityName: "Language Study",
             activityEmoji: "📚",
             activityColorHex: "#FFB3BA"
         )

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -73,11 +73,10 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
             activityIcon(context: context, size: 50)
 
             Text(context.attributes.activityName)
-                .font(.system(size: 14, weight: .semibold, design: .rounded))
+                .font(.system(size: 20, weight: .semibold, design: .rounded))
                 .lineLimit(1)
-                .layoutPriority(1)
 
-            Spacer()
+            Spacer(minLength: 8)
 
             Text(
                 timerInterval: context.state.timerStartDate...Date.distantFuture,
@@ -87,6 +86,8 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
             .monospacedDigit()
             .multilineTextAlignment(.trailing)
             .foregroundStyle(activityColor(hex: context.attributes.activityColorHex))
+            .frame(minWidth: 90, alignment: .trailing)
+            
         }
         .padding(20)
         .activityBackgroundTint(Color(.systemBackground))
@@ -145,7 +146,7 @@ private extension Color {
 extension TimerActivityAttributes {
     fileprivate static var preview: TimerActivityAttributes {
         TimerActivityAttributes(
-            activityName: "Language Study",
+            activityName: "Language Study ",
             activityEmoji: "📚",
             activityColorHex: "#FFB3BA"
         )

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -44,15 +44,17 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 }
             } compactLeading: {
                 // MARK: - Compact Leading
-                activityIcon(context: context, size: 18)
+                Text(context.attributes.activityEmoji.isEmpty ? "⏱" : context.attributes.activityEmoji)
+                    .font(.system(size: 14))
             } compactTrailing: {
                 // MARK: - Compact Trailing
                 Text(
                     timerInterval: context.state.timerStartDate...Date.distantFuture,
                     countsDown: false
                 )
-                .font(.system(.caption2, design: .rounded, weight: .semibold))
+                .font(.system(size: 12, weight: .semibold, design: .rounded))
                 .monospacedDigit()
+                .frame(width: 42)
             } minimal: {
                 // MARK: - Minimal
                 activityIcon(context: context, size: 22)

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -74,7 +74,8 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
 
             Text(context.attributes.activityName)
                 .font(.system(size: 20, weight: .semibold, design: .rounded))
-                .lineLimit(1)
+                .lineLimit(2)
+                
 
             Spacer(minLength: 8)
 
@@ -89,7 +90,7 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
             .frame(minWidth: 90, alignment: .trailing)
             
         }
-        .padding(20)
+        .padding(25)
         .activityBackgroundTint(Color(.systemBackground))
         .activitySystemActionForegroundColor(activityColor(hex: context.attributes.activityColorHex))
     }
@@ -146,7 +147,7 @@ private extension Color {
 extension TimerActivityAttributes {
     fileprivate static var preview: TimerActivityAttributes {
         TimerActivityAttributes(
-            activityName: "Language Study ",
+            activityName: "Meditation Exercise ",
             activityEmoji: "📚",
             activityColorHex: "#FFB3BA"
         )

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -61,15 +61,9 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
         HStack(spacing: 14) {
             activityIcon(context: context, size: 44)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(context.attributes.activityName)
-                    .font(.system(.headline, design: .rounded, weight: .semibold))
-                    .lineLimit(1)
-
-                Text("Timer running")
-                    .font(.system(.caption, design: .rounded))
-                    .foregroundStyle(.secondary)
-            }
+            Text(context.attributes.activityName)
+                .font(.system(.headline, design: .rounded, weight: .semibold))
+                .lineLimit(1)
 
             Spacer()
 

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -21,6 +21,10 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 DynamicIslandExpandedRegion(.leading) {
                     activityIcon(context: context, size: 36)
                 }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(context.attributes.activityName)
+                        .font(.system(.body, design: .rounded, weight: .medium))
+                }
                 DynamicIslandExpandedRegion(.trailing) {
                     Text(
                         timerInterval: context.state.timerStartDate...Date.distantFuture,
@@ -28,12 +32,8 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                     )
                     .font(.system(.title2, design: .rounded, weight: .bold))
                     .monospacedDigit()
+                    .multilineTextAlignment(.trailing)
                     .frame(maxWidth: .infinity, alignment: .trailing)
-                }
-                DynamicIslandExpandedRegion(.bottom) {
-                    Text(context.attributes.activityName)
-                        .font(.system(.body, design: .rounded, weight: .medium))
-                        .foregroundStyle(.secondary)
                 }
             } compactLeading: {
                 // MARK: - Compact Leading
@@ -46,11 +46,12 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 )
                 .font(.system(.caption, design: .rounded, weight: .semibold))
                 .monospacedDigit()
-                .frame(width: 52)
+                .multilineTextAlignment(.trailing)
             } minimal: {
                 // MARK: - Minimal
                 activityIcon(context: context, size: 22)
             }
+            .keylineTint(activityColor(hex: context.attributes.activityColorHex))
         }
     }
 
@@ -147,7 +148,25 @@ extension TimerActivityAttributes.ContentState {
     }
 }
 
-#Preview("Notification", as: .content, using: TimerActivityAttributes.preview) {
+#Preview("Lock Screen", as: .content, using: TimerActivityAttributes.preview) {
+    TimeMyLifeWidgetsLiveActivity()
+} contentStates: {
+    TimerActivityAttributes.ContentState.running
+}
+
+#Preview("Dynamic Island Compact", as: .dynamicIsland(.compact), using: TimerActivityAttributes.preview) {
+    TimeMyLifeWidgetsLiveActivity()
+} contentStates: {
+    TimerActivityAttributes.ContentState.running
+}
+
+#Preview("Dynamic Island Expanded", as: .dynamicIsland(.expanded), using: TimerActivityAttributes.preview) {
+    TimeMyLifeWidgetsLiveActivity()
+} contentStates: {
+    TimerActivityAttributes.ContentState.running
+}
+
+#Preview("Dynamic Island Minimal", as: .dynamicIsland(.minimal), using: TimerActivityAttributes.preview) {
     TimeMyLifeWidgetsLiveActivity()
 } contentStates: {
     TimerActivityAttributes.ContentState.running

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -56,6 +56,7 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 .font(.system(size: 12, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .frame(width: 42)
+                .padding(.trailing, 4)
             } minimal: {
                 // MARK: - Minimal
                 activityIcon(context: context, size: 22)
@@ -68,22 +69,20 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
 
     @ViewBuilder
     private func lockScreenView(context: ActivityViewContext<TimerActivityAttributes>) -> some View {
-        HStack(spacing: 10) {
-            activityIcon(context: context, size: 38)
+        HStack(spacing: 14) {
+            activityIcon(context: context, size: 44)
 
             Text(context.attributes.activityName)
                 .font(.system(.headline, design: .rounded, weight: .semibold))
                 .lineLimit(1)
-                .minimumScaleFactor(0.7)
-                .layoutPriority(1)
 
-            Spacer(minLength: 8)
+            Spacer()
 
             Text(
                 timerInterval: context.state.timerStartDate...Date.distantFuture,
                 countsDown: false
             )
-            .font(.system(.title3, design: .rounded, weight: .bold))
+            .font(.system(.title, design: .rounded, weight: .bold))
             .monospacedDigit()
             .multilineTextAlignment(.trailing)
             .frame(alignment: .trailing)

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -19,12 +19,14 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
             DynamicIsland {
                 // MARK: - Expanded Dynamic Island
                 DynamicIslandExpandedRegion(.bottom) {
-                    HStack(alignment: .center, spacing: 10) {
-                        activityIcon(context: context, size: 32)
+                    HStack(alignment: .center, spacing: 12) {
+                        Text(context.attributes.activityEmoji.isEmpty ? "⏱" : context.attributes.activityEmoji)
+                            .font(.system(size: 36))
 
                         Text(context.attributes.activityName)
-                            .font(.system(.body, design: .rounded, weight: .medium))
+                            .font(.system(.title2, design: .rounded, weight: .semibold))
                             .lineLimit(1)
+                            .foregroundStyle(.white)
 
                         Spacer()
 
@@ -32,10 +34,13 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                             timerInterval: context.state.timerStartDate...Date.distantFuture,
                             countsDown: false
                         )
-                        .font(.system(.title3, design: .rounded, weight: .bold))
+                        .font(.system(.title, design: .rounded, weight: .bold))
                         .monospacedDigit()
                         .multilineTextAlignment(.trailing)
+                        .foregroundStyle(activityColor(hex: context.attributes.activityColorHex))
                     }
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
                 }
             } compactLeading: {
                 // MARK: - Compact Leading

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -46,6 +46,7 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
                 // MARK: - Compact Leading
                 Text(context.attributes.activityEmoji.isEmpty ? "⏱" : context.attributes.activityEmoji)
                     .font(.system(size: 14))
+                    .padding(.leading, 4)
             } compactTrailing: {
                 // MARK: - Compact Trailing
                 Text(
@@ -67,24 +68,27 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
 
     @ViewBuilder
     private func lockScreenView(context: ActivityViewContext<TimerActivityAttributes>) -> some View {
-        HStack(spacing: 14) {
-            activityIcon(context: context, size: 44)
+        HStack(spacing: 10) {
+            activityIcon(context: context, size: 38)
 
             Text(context.attributes.activityName)
                 .font(.system(.headline, design: .rounded, weight: .semibold))
                 .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .layoutPriority(1)
 
-            Spacer()
+            Spacer(minLength: 8)
 
             Text(
                 timerInterval: context.state.timerStartDate...Date.distantFuture,
                 countsDown: false
             )
-            .font(.system(.title, design: .rounded, weight: .bold))
+            .font(.system(.title3, design: .rounded, weight: .bold))
             .monospacedDigit()
             .multilineTextAlignment(.trailing)
             .frame(alignment: .trailing)
             .foregroundStyle(activityColor(hex: context.attributes.activityColorHex))
+            .fixedSize()
         }
         .padding(16)
         .activityBackgroundTint(Color(.systemBackground))

--- a/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
+++ b/TimeMyLifeWidgets/TimeMyLifeWidgetsLiveActivity.swift
@@ -18,35 +18,36 @@ struct TimeMyLifeWidgetsLiveActivity: Widget {
         } dynamicIsland: { context in
             DynamicIsland {
                 // MARK: - Expanded Dynamic Island
-                DynamicIslandExpandedRegion(.leading) {
-                    activityIcon(context: context, size: 36)
-                }
-                DynamicIslandExpandedRegion(.center) {
-                    Text(context.attributes.activityName)
-                        .font(.system(.body, design: .rounded, weight: .medium))
-                }
-                DynamicIslandExpandedRegion(.trailing) {
-                    Text(
-                        timerInterval: context.state.timerStartDate...Date.distantFuture,
-                        countsDown: false
-                    )
-                    .font(.system(.title2, design: .rounded, weight: .bold))
-                    .monospacedDigit()
-                    .multilineTextAlignment(.trailing)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack(alignment: .center, spacing: 10) {
+                        activityIcon(context: context, size: 32)
+
+                        Text(context.attributes.activityName)
+                            .font(.system(.body, design: .rounded, weight: .medium))
+                            .lineLimit(1)
+
+                        Spacer()
+
+                        Text(
+                            timerInterval: context.state.timerStartDate...Date.distantFuture,
+                            countsDown: false
+                        )
+                        .font(.system(.title3, design: .rounded, weight: .bold))
+                        .monospacedDigit()
+                        .multilineTextAlignment(.trailing)
+                    }
                 }
             } compactLeading: {
                 // MARK: - Compact Leading
-                activityIcon(context: context, size: 24)
+                activityIcon(context: context, size: 18)
             } compactTrailing: {
                 // MARK: - Compact Trailing
                 Text(
                     timerInterval: context.state.timerStartDate...Date.distantFuture,
                     countsDown: false
                 )
-                .font(.system(.caption, design: .rounded, weight: .semibold))
+                .font(.system(.caption2, design: .rounded, weight: .semibold))
                 .monospacedDigit()
-                .multilineTextAlignment(.trailing)
             } minimal: {
                 // MARK: - Minimal
                 activityIcon(context: context, size: 22)


### PR DESCRIPTION
## Summary
- Add ActivityKit Live Activity showing running timer on Lock Screen and Dynamic Island
- Create `TimerActivityAttributes` shared model between main app and widget extension
- Create `LiveActivityService` to manage Live Activity lifecycle (start/stop/cleanup)
- Integrate with `TimerService` — Live Activity auto-starts/stops with timer
- Add `TimeMyLifeWidgets` widget extension with compact, expanded, and minimal Dynamic Island views
- Timer uses `Text(.timerInterval:)` for system-managed live counting (no push updates needed)
- Live Activity timer includes accumulated time for the day, matching the in-app display

Closes #23

## Files Changed
- **New**: `TimerActivityAttributes.swift`, `LiveActivityService.swift`, `TimeMyLifeWidgets/` (widget extension)
- **Modified**: `TimerService.swift` (Live Activity calls on start/stop/resume/reset + accumulated time fetch), `Info.plist` (NSSupportsLiveActivities), `project.pbxproj` (widget target + shared file)

## Test plan
- [x] Start a timer → verify Live Activity appears on Lock Screen
- [x] Verify Dynamic Island shows activity emoji + live timer
- [ ] Verify timer on widget matches in-app timer (includes accumulated time)
- [x] Tap Live Activity → verify it opens the app
- [ ] Stop the timer → verify Live Activity dismisses immediately
- [ ] Background the app with timer running → verify Live Activity persists
- [ ] Kill and relaunch app with timer running → verify Live Activity resumes
- [ ] Test with long activity names → verify 2-line wrap on Lock Screen