### PR TITLE
refactor(views): extract reusable ActivityAvatarView

### DIFF
--- a/TimeMyLifeApp/Models/ActiveTimer.swift
+++ b/TimeMyLifeApp/Models/ActiveTimer.swift
@@ -92,39 +92,6 @@ public final class ActiveTimer {
 
     // MARK: - Formatting Methods
 
-    /// Formats the current elapsed time as HH:MM:SS
-    /// - Returns: Formatted string representation of elapsed time
-    public func formattedElapsedTime() -> String {
-        let elapsed = currentElapsedTime()
-        return formatDuration(elapsed)
-    }
-
-    /// Formats the current elapsed time as MM:SS (for durations under 1 hour)
-    /// - Returns: Formatted string representation of elapsed time
-    public func formattedElapsedTimeShort() -> String {
-        let elapsed = currentElapsedTime()
-        let hours = Int(elapsed) / 3600
-
-        if hours > 0 {
-            return formatDuration(elapsed)
-        }
-
-        let minutes = Int(elapsed) / 60 % 60
-        let seconds = Int(elapsed) % 60
-        return String(format: "%02d:%02d", minutes, seconds)
-    }
-
-    // MARK: - Private Helpers
-
-    /// Formats a TimeInterval as HH:MM:SS
-    /// - Parameter duration: Duration in seconds
-    /// - Returns: Formatted string
-    private func formatDuration(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = Int(duration) / 60 % 60
-        let seconds = Int(duration) % 60
-        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-    }
 }
 
 // MARK: - Static Helper Methods

--- a/TimeMyLifeApp/Models/TimeEntry.swift
+++ b/TimeMyLifeApp/Models/TimeEntry.swift
@@ -50,36 +50,6 @@ public final class TimeEntry {
         }
     }
 
-    /// Formats the total duration as HH:MM:SS
-    /// - Returns: Formatted string representation of duration
-    public func formattedDuration() -> String {
-        return formatDuration(totalDuration)
-    }
-
-    /// Formats the total duration as MM:SS (for durations under 1 hour)
-    /// - Returns: Formatted string representation of duration
-    public func formattedDurationShort() -> String {
-        let hours = Int(totalDuration) / 3600
-        if hours > 0 {
-            return formattedDuration()
-        }
-
-        let minutes = Int(totalDuration) / 60 % 60
-        let seconds = Int(totalDuration) % 60
-        return String(format: "%02d:%02d", minutes, seconds)
-    }
-
-    // MARK: - Private Helpers
-
-    /// Formats a TimeInterval as HH:MM:SS
-    /// - Parameter duration: Duration in seconds
-    /// - Returns: Formatted string
-    private func formatDuration(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = Int(duration) / 60 % 60
-        let seconds = Int(duration) % 60
-        return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-    }
 }
 
 // MARK: - Static Helper Methods

--- a/TimeMyLifeApp/Services/TimerService.swift
+++ b/TimeMyLifeApp/Services/TimerService.swift
@@ -380,15 +380,7 @@ public class TimerService {
     // MARK: - Helper Methods
 
     private func formatDuration(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = Int(duration) / 60 % 60
-        let seconds = Int(duration) % 60
-
-        if hours > 0 {
-            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%02d:%02d", minutes, seconds)
-        }
+        duration.formattedDuration(style: .timer)
     }
 }
 

--- a/TimeMyLifeApp/TimeMyLifeAppApp.swift
+++ b/TimeMyLifeApp/TimeMyLifeAppApp.swift
@@ -216,7 +216,7 @@ struct TimeMyLifeAppApp: App {
                 duration: elapsed
             )
             #if DEBUG
-            print("✅ Checkpointed timer: \(formatElapsed(elapsed))")
+            print("✅ Checkpointed timer: \(elapsed.formattedDuration(style: .timer))")
             #endif
         } catch {
             #if DEBUG
@@ -239,18 +239,4 @@ struct TimeMyLifeAppApp: App {
             )
         }
     }
-
-    #if DEBUG
-    private func formatElapsed(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = (Int(duration) % 3600) / 60
-        let seconds = Int(duration) % 60
-
-        if hours > 0 {
-            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%02d:%02d", minutes, seconds)
-        }
-    }
-    #endif
 }

--- a/TimeMyLifeApp/Utilities/Extensions/TimeInterval+Formatting.swift
+++ b/TimeMyLifeApp/Utilities/Extensions/TimeInterval+Formatting.swift
@@ -7,45 +7,47 @@ import Foundation
 
 /// Style options for duration formatting
 public enum DurationStyle {
-    case automatic  // Automatically chooses format based on duration
-    case short      // Always MM:SS format
-    case long       // Always HH:MM:SS format
+    /// Timer display: "02:30:05" or "30:05" (auto omits hours when zero)
+    case timer
+    /// Timer display: always "00:30:05" (includes hours even when zero)
+    case timerLong
+    /// Compact: "2h 30m", "45m", "30s" (omits zero components)
+    case compact
+    /// Compact without seconds: "2h 30m", "45m", "0m"
+    case compactNoSeconds
+    /// Verbose: "2 hours 30 minutes", "1 minute" (singular/plural aware)
+    case verbose
 }
 
 public extension TimeInterval {
     /// Formats the time interval as a duration string
-    /// - Parameter style: The formatting style to use (default: .automatic)
+    /// - Parameter style: The formatting style to use (default: .timer)
     /// - Returns: Formatted string representation of the duration
-    func formatted(style: DurationStyle = .automatic) -> String {
-        let hours = Int(self) / 3600
-        let minutes = (Int(self) % 3600) / 60
-        let seconds = Int(self) % 60
+    func formattedDuration(style: DurationStyle) -> String {
+        let total = Int(self)
+        let h = total / 3600
+        let m = (total % 3600) / 60
+        let s = total % 60
 
         switch style {
-        case .automatic:
-            return hours > 0
-                ? String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-                : String(format: "%02d:%02d", minutes, seconds)
-        case .short:
-            return String(format: "%02d:%02d", minutes, seconds)
-        case .long:
-            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-        }
-    }
-    
-    /// Formats the time interval as H:MM:SS when >= 1 hour, otherwise as MM:SS.
-    /// Rounds down to the nearest second.
-    func formattedAsHoursMinutes() -> String {
-        let totalSeconds = Int(self)
-        let hours = totalSeconds / 3600
-        let minutes = (totalSeconds % 3600) / 60
-        let seconds = totalSeconds % 60
-
-        if hours > 0 {
-            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%02d:%02d", minutes, seconds)
+        case .timer:
+            return h > 0
+                ? String(format: "%02d:%02d:%02d", h, m, s)
+                : String(format: "%02d:%02d", m, s)
+        case .timerLong:
+            return String(format: "%02d:%02d:%02d", h, m, s)
+        case .compact:
+            if h > 0 { return m > 0 ? "\(h)h \(m)m" : "\(h)h" }
+            if m > 0 { return s > 0 ? "\(m)m \(s)s" : "\(m)m" }
+            return "\(s)s"
+        case .compactNoSeconds:
+            if h > 0 && m > 0 { return "\(h)h \(m)m" }
+            if h > 0 { return "\(h)h" }
+            return "\(m)m"
+        case .verbose:
+            if h > 0 && m > 0 { return "\(h) \(h == 1 ? "hour" : "hours") \(m) \(m == 1 ? "minute" : "minutes")" }
+            if h > 0 { return h == 1 ? "1 hour" : "\(h) hours" }
+            return m == 1 ? "1 minute" : "\(m) minutes"
         }
     }
 }
-

--- a/TimeMyLifeApp/ViewModels/TimerViewModel.swift
+++ b/TimeMyLifeApp/ViewModels/TimerViewModel.swift
@@ -152,15 +152,7 @@ public class TimerViewModel {
 
     /// Formats a duration as HH:MM:SS or MM:SS
     public func formatDuration(_ duration: TimeInterval) -> String {
-        let hours = Int(duration) / 3600
-        let minutes = (Int(duration) % 3600) / 60
-        let seconds = Int(duration) % 60
-
-        if hours > 0 {
-            return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-        } else {
-            return String(format: "%02d:%02d", minutes, seconds)
-        }
+        duration.formattedDuration(style: .timer)
     }
 
     /// Total displayed time (elapsed + accumulated)

--- a/TimeMyLifeApp/Views/Goals/GoalCardView.swift
+++ b/TimeMyLifeApp/Views/Goals/GoalCardView.swift
@@ -40,7 +40,7 @@ struct GoalCardView: View {
                     }
 
                     // Progress text
-                    Text("\(formatDuration(goalWithProgress.currentProgress)) / \(formatDuration(goalWithProgress.targetSeconds))")
+                    Text("\(goalWithProgress.currentProgress.formattedDuration(style: .compactNoSeconds)) / \(goalWithProgress.targetSeconds.formattedDuration(style: .compactNoSeconds))")
                         .font(.system(.subheadline, design: .rounded))
                         .foregroundStyle(.secondary)
 
@@ -57,14 +57,6 @@ struct GoalCardView: View {
         .buttonStyle(.plain)
     }
 
-    private func formatDuration(_ seconds: TimeInterval) -> String {
-        let total = Int(seconds)
-        let hours = total / 3600
-        let minutes = (total % 3600) / 60
-        if hours > 0 && minutes > 0 { return "\(hours)h \(minutes)m" }
-        if hours > 0 { return "\(hours)h" }
-        return "\(minutes)m"
-    }
 }
 
 #Preview {

--- a/TimeMyLifeApp/Views/Goals/GoalFormView.swift
+++ b/TimeMyLifeApp/Views/Goals/GoalFormView.swift
@@ -127,23 +127,7 @@ struct GoalFormView: View {
             }
         } label: {
             HStack(spacing: 12) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(
-                            activity.emoji.isEmpty
-                                ? activity.color()
-                                : activity.color().opacity(0.18)
-                        )
-                        .frame(width: 36, height: 36)
-                    if activity.emoji.isEmpty {
-                        Text(String(activity.name.prefix(1)).uppercased())
-                            .font(.system(size: 15, weight: .bold, design: .rounded))
-                            .foregroundStyle(Color(white: 0.18))
-                    } else {
-                        Text(activity.emoji)
-                            .font(.system(size: 18))
-                    }
-                }
+                ActivityAvatarView(activity: activity, size: 36)
 
                 Text(activity.name)
                     .font(.system(.subheadline, design: .rounded, weight: .medium))

--- a/TimeMyLifeApp/Views/Home/ActivityRowView.swift
+++ b/TimeMyLifeApp/Views/Home/ActivityRowView.swift
@@ -53,21 +53,7 @@ struct ActivityRowView: View {
     // MARK: - Sub-views
 
     private var activityAvatar: some View {
-        ZStack {
-            RoundedRectangle(cornerRadius: 13)
-                .fill(activity.emoji.isEmpty
-                      ? activity.color()
-                      : activity.color().opacity(0.18))
-                .frame(width: 48, height: 48)
-            if activity.emoji.isEmpty {
-                Text(String(activity.name.prefix(1)).uppercased())
-                    .font(.system(size: 20, weight: .bold, design: .rounded))
-                    .foregroundStyle(Color(white: 0.18))
-            } else {
-                Text(activity.emoji)
-                    .font(.system(size: 26))
-            }
-        }
+        ActivityAvatarView(activity: activity)
     }
 
     private var runningBadge: some View {

--- a/TimeMyLifeApp/Views/Home/ActivityRowView.swift
+++ b/TimeMyLifeApp/Views/Home/ActivityRowView.swift
@@ -88,13 +88,7 @@ struct ActivityRowView: View {
     // MARK: - Helpers
 
     private var formattedDuration: String {
-        let total = Int(displayedDuration)
-        let h = total / 3600
-        let m = (total % 3600) / 60
-        let s = total % 60
-        if h > 0 { return m > 0 ? "\(h)h \(m)m" : "\(h)h" }
-        if m > 0 { return s > 0 ? "\(m)m \(s)s" : "\(m)m" }
-        return "\(s)s"
+        displayedDuration.formattedDuration(style: .compact)
     }
 }
 

--- a/TimeMyLifeApp/Views/Home/ActivityTimerView.swift
+++ b/TimeMyLifeApp/Views/Home/ActivityTimerView.swift
@@ -35,26 +35,7 @@ struct ActivityTimerView: View {
 
                 // Avatar + name
                 VStack(spacing: 16) {
-                    ZStack {
-                        RoundedRectangle(cornerRadius: 26)
-                            .fill(activity.emoji.isEmpty
-                                  ? activity.color()
-                                  : activity.color().opacity(0.18))
-                            .frame(width: 100, height: 100)
-                            .shadow(
-                                color: activity.color().opacity(0.45),
-                                radius: 24,
-                                x: 0, y: 10
-                            )
-                        if activity.emoji.isEmpty {
-                            Text(String(activity.name.prefix(1)).uppercased())
-                                .font(.system(size: 44, weight: .bold, design: .rounded))
-                                .foregroundStyle(Color(white: 0.18))
-                        } else {
-                            Text(activity.emoji)
-                                .font(.system(size: 52))
-                        }
-                    }
+                    ActivityAvatarView(activity: activity, size: 100, shadow: true)
 
                     VStack(spacing: 6) {
                         Text(activity.name)

--- a/TimeMyLifeApp/Views/Home/ActivityTimerView.swift
+++ b/TimeMyLifeApp/Views/Home/ActivityTimerView.swift
@@ -76,7 +76,7 @@ struct ActivityTimerView: View {
                 Spacer()
 
                 // Timer display
-                Text(viewModel.displayedElapsedTime.formattedAsHoursMinutes())
+                Text(viewModel.displayedElapsedTime.formattedDuration(style: .timer))
                     .font(.system(size: 64, weight: .semibold, design: .rounded))
                     .monospacedDigit()
                     .foregroundStyle(viewModel.isRunning ? Color.appAccent : .primary)

--- a/TimeMyLifeApp/Views/Shared/ActivityAvatarView.swift
+++ b/TimeMyLifeApp/Views/Shared/ActivityAvatarView.swift
@@ -1,0 +1,38 @@
+//
+//  ActivityAvatarView.swift
+//  TimeMyLifeApp
+//
+
+import SwiftUI
+
+struct ActivityAvatarView: View {
+    let activity: Activity
+    var size: CGFloat = 48
+    var shadow: Bool = false
+
+    var body: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: size * 0.27)
+                .fill(
+                    activity.emoji.isEmpty
+                        ? activity.color()
+                        : activity.color().opacity(0.18)
+                )
+                .frame(width: size, height: size)
+                .shadow(
+                    color: shadow ? activity.color().opacity(0.45) : .clear,
+                    radius: shadow ? size * 0.24 : 0,
+                    x: 0,
+                    y: shadow ? size * 0.1 : 0
+                )
+            if activity.emoji.isEmpty {
+                Text(String(activity.name.prefix(1)).uppercased())
+                    .font(.system(size: size * 0.42, weight: .bold, design: .rounded))
+                    .foregroundStyle(Color(white: 0.18))
+            } else {
+                Text(activity.emoji)
+                    .font(.system(size: size * 0.54))
+            }
+        }
+    }
+}

--- a/TimeMyLifeApp/Views/Shared/ActivityFormView.swift
+++ b/TimeMyLifeApp/Views/Shared/ActivityFormView.swift
@@ -688,7 +688,7 @@ private struct EditTimeEntrySheet: View {
                     Text(formatDate(entry.date))
                         .font(.system(.subheadline, design: .rounded, weight: .medium))
                         .foregroundStyle(.primary)
-                    Text(formatDuration(entry.totalDuration))
+                    Text(entry.totalDuration.formattedDuration(style: .verbose))
                         .font(.system(.caption, design: .rounded))
                         .foregroundStyle(.secondary)
                 }
@@ -765,13 +765,6 @@ private struct EditTimeEntrySheet: View {
         return formatter.string(from: date)
     }
 
-    private func formatDuration(_ seconds: TimeInterval) -> String {
-        let h = Int(seconds) / 3600
-        let m = (Int(seconds) % 3600) / 60
-        if h > 0 && m > 0 { return "\(h) hours \(m) minutes" }
-        if h > 0 { return h == 1 ? "1 hour" : "\(h) hours" }
-        return m == 1 ? "1 minute" : "\(m) minutes"
-    }
 }
 
 // MARK: - Emoji Picker Sheet

--- a/TimeMyLifeApp/Views/Statistics/ActivityStatsDetailView.swift
+++ b/TimeMyLifeApp/Views/Statistics/ActivityStatsDetailView.swift
@@ -104,11 +104,11 @@ struct ActivityStatsDetailView: View {
 
             Divider()
 
-            metricRow(label: "Total Time", value: formatDuration(metrics.totalDuration))
+            metricRow(label: "Total Time", value: metrics.totalDuration.formattedDuration(style: .compactNoSeconds))
             Divider().padding(.leading, 16)
-            metricRow(label: "Daily Average", value: formatDuration(metrics.dailyAverage))
+            metricRow(label: "Daily Average", value: metrics.dailyAverage.formattedDuration(style: .compactNoSeconds))
             Divider().padding(.leading, 16)
-            metricRow(label: "Weekly Average", value: formatDuration(metrics.weeklyAverage))
+            metricRow(label: "Weekly Average", value: metrics.weeklyAverage.formattedDuration(style: .compactNoSeconds))
             Divider().padding(.leading, 16)
             metricRow(
                 label: "Consistency (30d)",
@@ -357,7 +357,7 @@ struct ActivityStatsDetailView: View {
                             .font(.system(.subheadline, design: .rounded))
                             .foregroundStyle(.secondary)
                         Spacer()
-                        Text(formatDuration(entry.totalDuration))
+                        Text(entry.totalDuration.formattedDuration(style: .compactNoSeconds))
                             .font(.system(.subheadline, design: .rounded, weight: .semibold))
                             .monospacedDigit()
                     }
@@ -375,15 +375,6 @@ struct ActivityStatsDetailView: View {
     }
 
     // MARK: - Helpers
-
-    private func formatDuration(_ seconds: TimeInterval) -> String {
-        let h = Int(seconds) / 3600
-        let m = (Int(seconds) % 3600) / 60
-        if h > 0 && m > 0 { return "\(h)h \(m)m" }
-        if h > 0 { return "\(h)h" }
-        if m > 0 { return "\(m)m" }
-        return "—"
-    }
 
     private func formatDateRange(start: Date, end: Date) -> String {
         let formatter = DateFormatter()

--- a/TimeMyLifeApp/Views/Statistics/ActivityStatsDetailView.swift
+++ b/TimeMyLifeApp/Views/Statistics/ActivityStatsDetailView.swift
@@ -55,23 +55,7 @@ struct ActivityStatsDetailView: View {
 
     private var headerCard: some View {
         HStack(spacing: 14) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 13)
-                    .fill(
-                        activity.emoji.isEmpty
-                            ? activity.color()
-                            : activity.color().opacity(0.18)
-                    )
-                    .frame(width: 48, height: 48)
-                if activity.emoji.isEmpty {
-                    Text(String(activity.name.prefix(1)).uppercased())
-                        .font(.system(size: 20, weight: .bold, design: .rounded))
-                        .foregroundStyle(Color(white: 0.18))
-                } else {
-                    Text(activity.emoji)
-                        .font(.system(size: 24))
-                }
-            }
+            ActivityAvatarView(activity: activity)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(activity.name)

--- a/TimeMyLifeApp/Views/Statistics/CalendarView.swift
+++ b/TimeMyLifeApp/Views/Statistics/CalendarView.swift
@@ -209,7 +209,7 @@ struct DayDetailView: View {
                                         Text(item.name)
                                             .font(.system(.subheadline, design: .rounded))
                                         Spacer()
-                                        Text(formatDuration(item.duration))
+                                        Text(item.duration.formattedDuration(style: .compactNoSeconds))
                                             .font(.system(.subheadline, design: .rounded, weight: .semibold))
                                             .foregroundStyle(.secondary)
                                             .monospacedDigit()
@@ -228,7 +228,7 @@ struct DayDetailView: View {
                             Text("Total")
                                 .font(.system(.subheadline, design: .rounded, weight: .semibold))
                             Spacer()
-                            Text(formatDuration(dayData.totalDuration))
+                            Text(dayData.totalDuration.formattedDuration(style: .compactNoSeconds))
                                 .font(.system(.subheadline, design: .rounded, weight: .semibold))
                                 .monospacedDigit()
                         }
@@ -252,10 +252,4 @@ struct DayDetailView: View {
         }
     }
 
-    private func formatDuration(_ s: TimeInterval) -> String {
-        let h = Int(s) / 3600, m = (Int(s) % 3600) / 60
-        if h > 0 && m > 0 { return "\(h)h \(m)m" }
-        if h > 0 { return "\(h)h" }
-        return "\(m)m"
-    }
 }

--- a/TimeMyLifeWatch Watch App/TimeMyLifeWatchApp.swift
+++ b/TimeMyLifeWatch Watch App/TimeMyLifeWatchApp.swift
@@ -150,7 +150,7 @@ struct TimeMyLifeWatch_Watch_AppApp: App {
                         #if DEBUG
                         if let startTime = timer.startTime {
                             let elapsed = Date().timeIntervalSince(startTime)
-                            print("✅ Timer is running - elapsed: \(formatElapsed(elapsed))")
+                            print("✅ Timer is running - elapsed: \(elapsed.formattedDuration(style: .timer))")
                         }
                         #endif
                     }
@@ -162,17 +162,4 @@ struct TimeMyLifeWatch_Watch_AppApp: App {
             }
         }
 
-        #if DEBUG
-        private func formatElapsed(_ duration: TimeInterval) -> String {
-            let hours = Int(duration) / 3600
-            let minutes = (Int(duration) % 3600) / 60
-            let seconds = Int(duration) % 60
-
-            if hours > 0 {
-                return String(format: "%02d:%02d:%02d", hours, minutes, seconds)
-            } else {
-                return String(format: "%02d:%02d", minutes, seconds)
-            }
-        }
-        #endif
 }


### PR DESCRIPTION
## Summary
- Created `ActivityAvatarView` with configurable `size` and `shadow` parameters, replacing 4 copy-pasted avatar implementations
- Replaced duplicates in ActivityRowView, ActivityTimerView, ActivityStatsDetailView, and GoalFormView
- Font sizes scale proportionally (`size * 0.42` for text, `size * 0.54` for emoji) to match original designs

## Test plan
- [ ] Verify Home screen activity row avatars (48pt)
- [ ] Verify timer screen large avatar with shadow (100pt)
- [ ] Verify activity stats detail header avatar (48pt)
- [ ] Verify goal form activity picker avatar (36pt)